### PR TITLE
fix: correct LinkedIn profile URL (#7)

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -12,7 +12,7 @@ const year = new Date().getFullYear();
     <div class="footer-bottom">
       <p class="text-muted">&copy; {year} Matt Upson</p>
       <div class="footer-links">
-        <a href="https://www.linkedin.com/in/mattupson/" target="_blank" rel="noopener">LinkedIn</a>
+        <a href="https://www.linkedin.com/in/maupson" target="_blank" rel="noopener">LinkedIn</a>
         <a href="https://reproducible.substack.com" target="_blank" rel="noopener">Substack</a>
         <a href="https://github.com/ivyleavedtoadflax" target="_blank" rel="noopener">GitHub</a>
       </div>


### PR DESCRIPTION
## Summary
- Changed LinkedIn footer link from `/in/mattupson/` to `/in/maupson` (the correct profile URL)

Fixes #7

## Test plan
- [x] Build passes
- [x] LinkedIn link in footer points to correct profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)