### PR TITLE
fix: add custom 404 page (#9)

### DIFF
--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,0 +1,29 @@
+---
+import Base from '../layouts/Base.astro';
+---
+
+<Base title="Page not found" description="The page you're looking for doesn't exist.">
+  <section>
+    <div class="container--narrow text-center not-found">
+      <h1>404</h1>
+      <p>The page you&rsquo;re looking for doesn&rsquo;t exist.</p>
+      <a href="/" class="btn btn--primary">Back to homepage</a>
+    </div>
+  </section>
+</Base>
+
+<style>
+  .not-found {
+    padding: 6rem 0;
+  }
+
+  .not-found h1 {
+    font-size: 4rem;
+    margin-bottom: 0.5rem;
+  }
+
+  .not-found p {
+    color: var(--color-text-muted);
+    margin-bottom: 2rem;
+  }
+</style>


### PR DESCRIPTION
## Summary
- Added a branded 404 page (`src/pages/404.astro`) using the Base layout
- Shows a friendly "Page not found" message with a link back to the homepage
- Replaces the default GitHub Pages 404

Fixes #9

## Test plan
- [x] Build passes (12 pages built)
- [x] 404 page uses site layout and styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)