### PR TITLE
fix: remove redundant Work with me nav link (#10)

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -5,7 +5,6 @@ const navLinks = [
   { href: '/about', label: 'About' },
   { href: '/services', label: 'Services' },
   { href: '/writing', label: 'Writing' },
-  { href: '/contact', label: 'Work with me' },
 ];
 ---
 


### PR DESCRIPTION
## Summary
- Removed the "Work with me" nav link that duplicated the /contact destination already served by the "Book a call" CTA button

Fixes #10

## Test plan
- [x] Build passes
- [x] "Book a call" CTA button still present

🤖 Generated with [Claude Code](https://claude.com/claude-code)