### PR TITLE
Make internal links base-aware for subpath deploys

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,45 @@ npm run preview   # preview production build locally
 
 ## Deployment
 
-Pushes to `main` automatically build and deploy via the workflow in `.github/workflows/deploy.yml`.
+Pushes to `main` build and publish `dist/` to the root of the `gh-pages` branch, via
+`.github/workflows/deploy.yml`. GitHub Pages serves that branch.
+
+### PR previews
+
+Every pull request from this repo is built and published to the `gh-pages` branch under
+`pr-preview/pr-<number>/`, and a bot comment on the PR links to it:
+
+```
+https://mattupson.com/pr-preview/pr-123/
+```
+
+The preview updates on each push and is deleted when the PR closes
+(`.github/workflows/pr-preview.yml`).
+
+Because previews are served from a subpath, **internal links must be base-aware**. Use the
+`url()` helper from `src/lib/url.ts` for root-relative paths rather than hardcoding them:
+
+```astro
+---
+import { url } from '../lib/url';
+---
+<a href={url('/services')}>Services</a>
+```
+
+A hardcoded `href="/services"` will jump out of the preview and back to the live site.
+Preview builds also emit `<meta name="robots" content="noindex, nofollow">` and canonicalise
+to the production URL, so they won't be indexed.
+
+Previews for pull requests from forks are skipped — forked PRs get a read-only token and
+can't publish to the branch.
+
+### One-time Pages setup
+
+This repo publishes from a branch rather than via the Pages Actions artifact (Pages allows
+only one deployment source, and per-PR previews need the branch). After the first `main`
+build creates `gh-pages`, set **Settings → Pages → Source** to *Deploy from a branch*, with
+branch `gh-pages` and folder `/ (root)`. The custom domain is preserved by `public/CNAME`,
+which ships in every build.
 
 ## License
 

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,4 +1,6 @@
 ---
+import { url } from '../lib/url';
+
 const currentPath = Astro.url.pathname;
 const navLinks = [
   { href: '/', label: 'Home' },
@@ -6,11 +8,16 @@ const navLinks = [
   { href: '/services', label: 'Services' },
   { href: '/writing', label: 'Writing' },
 ];
+
+const isActive = (href: string) => {
+  const target = url(href);
+  return currentPath === target || currentPath === `${target}/` || (href !== '/' && currentPath.startsWith(target));
+};
 ---
 
 <header class="site-header">
   <div class="container header-inner">
-    <a href="/" class="site-name">Matt Upson</a>
+    <a href={url('/')} class="site-name">Matt Upson</a>
     <nav>
       <button class="menu-toggle" aria-label="Toggle menu" aria-expanded="false">
         <span></span><span></span><span></span>
@@ -18,7 +25,7 @@ const navLinks = [
       <ul class="nav-links">
         {navLinks.map(link => (
           <li>
-            <a href={link.href} class:list={[{ active: currentPath === link.href || (link.href !== '/' && currentPath.startsWith(link.href)) }]}>
+            <a href={url(link.href)} class:list={[{ active: isActive(link.href) }]}>
               {link.label}
             </a>
           </li>

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -2,6 +2,7 @@
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
 import '../styles/global.css';
+import { url, isPreview, stripBase } from '../lib/url';
 
 interface Props {
   title: string;
@@ -11,7 +12,7 @@ interface Props {
 }
 
 const { title, description = 'Senior AI leadership for organisations that need expertise, not hype.', ogImage = '/og-default.png', hideFooterCta = false } = Astro.props;
-const canonicalUrl = new URL(Astro.url.pathname, Astro.site).href;
+const canonicalUrl = new URL(stripBase(Astro.url.pathname), Astro.site).href;
 const ogImageUrl = new URL(ogImage, Astro.site).href;
 const fullTitle = title === 'Home' ? 'Matt Upson' : `${title} | Matt Upson`;
 ---
@@ -22,11 +23,12 @@ const fullTitle = title === 'Home' ? 'Matt Upson' : `${title} | Matt Upson`;
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content={description} />
-    <link rel="icon" href="/favicon.ico" sizes="32x32" />
-    <link rel="icon" href="/icon-192.png" type="image/png" sizes="192x192" />
-    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+    <link rel="icon" href={url('/favicon.ico')} sizes="32x32" />
+    <link rel="icon" href={url('/icon-192.png')} type="image/png" sizes="192x192" />
+    <link rel="apple-touch-icon" href={url('/apple-touch-icon.png')} />
     <link rel="canonical" href={canonicalUrl} />
-    <link rel="alternate" type="application/rss+xml" title="Matt Upson" href="/rss.xml" />
+    <link rel="alternate" type="application/rss+xml" title="Matt Upson" href={url('/rss.xml')} />
+    {isPreview && <meta name="robots" content="noindex, nofollow" />}
 
     <!-- Open Graph -->
     <meta property="og:type" content="website" />

--- a/src/lib/url.ts
+++ b/src/lib/url.ts
@@ -1,0 +1,24 @@
+/**
+ * Base-aware URL helpers.
+ *
+ * Production builds use the default base ("/"), but PR preview builds are served
+ * from a subpath (e.g. /pr-preview/pr-123/), so internal links must be prefixed
+ * with it. Wrap root-relative internal paths in `url()` instead of hardcoding
+ * them, or they will escape the preview and land on the live site.
+ */
+
+const BASE = import.meta.env.BASE_URL.replace(/\/+$/, '');
+
+/** True when the site is served from a subpath, i.e. this is a PR preview build. */
+export const isPreview = BASE !== '';
+
+/** Prefix a root-relative path with the configured base. Leaves other URLs alone. */
+export function url(path: string): string {
+  return path.startsWith('/') ? `${BASE}${path}` : path;
+}
+
+/** Strip the base off a pathname, so canonical URLs always point at production. */
+export function stripBase(pathname: string): string {
+  if (!BASE || !pathname.startsWith(BASE)) return pathname;
+  return pathname.slice(BASE.length) || '/';
+}

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,5 +1,6 @@
 ---
 import Base from '../layouts/Base.astro';
+import { url } from '../lib/url';
 ---
 
 <Base title="Page not found" description="The page you're looking for doesn't exist.">
@@ -7,7 +8,7 @@ import Base from '../layouts/Base.astro';
     <div class="container--narrow text-center not-found">
       <h1>404</h1>
       <p>The page you&rsquo;re looking for doesn&rsquo;t exist.</p>
-      <a href="/" class="btn btn--primary">Back to homepage</a>
+      <a href={url('/')} class="btn btn--primary">Back to homepage</a>
     </div>
   </section>
 </Base>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,11 +1,12 @@
 ---
 import Base from '../layouts/Base.astro';
+import { url } from '../lib/url';
 ---
 
 <Base title="About" description="The career arc from environmental scientist to AI consultant, via government, startups, and Valencia.">
   <section>
     <div class="container--narrow about-intro">
-      <img src="/icon-512.png" alt="Matt Upson" class="headshot" />
+      <img src={url('/icon-512.png')} alt="Matt Upson" class="headshot" />
       <div>
         <h1>About</h1>
         <p class="lead mt-3">I&rsquo;ve spent the last decade building AI systems and leading teams in government, not-for-profits, and startups. I co-founded Mantis NLP, an AI consultancy, and served as CEO and then CTO over five years. I now work independently with organisations who need senior AI capability without the overhead of a full-time hire.</p>
@@ -79,14 +80,14 @@ import Base from '../layouts/Base.astro';
     <div class="container--narrow">
       <h2>More</h2>
       <div class="more-links">
-        <a href="/archive" class="card-link">
+        <a href={url('/archive')} class="card-link">
           <div class="card">
             <h3>Blog archive</h3>
             <p class="text-muted">Everything I&rsquo;ve written since 2014, across Medium, Substack, government blogs, and machinegurning.blog.</p>
             <span class="read-more">View archive &rarr;</span>
           </div>
         </a>
-        <a href="/papers" class="card-link">
+        <a href={url('/papers')} class="card-link">
           <div class="card">
             <h3>Academic papers</h3>
             <p class="text-muted">Publications in data science, agroforestry, and soil carbon from my previous life as an environmental scientist.</p>

--- a/src/pages/archive.astro
+++ b/src/pages/archive.astro
@@ -1,13 +1,14 @@
 ---
 import Base from '../layouts/Base.astro';
 import { getCollection } from 'astro:content';
+import { url } from '../lib/url';
 
 // Get local blog posts from content collection
 const localPosts = (await getCollection('posts'))
   .filter(p => !p.data.draft)
   .map(p => ({
     title: p.data.title,
-    url: `/writing/${p.id}`,
+    url: url(`/writing/${p.id}`),
     source: 'This site' as string,
     date: new Date(p.data.date),
     originalUrl: p.data.originalUrl,

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,7 @@
 ---
 import Base from '../layouts/Base.astro';
 import { getCollection } from 'astro:content';
+import { url } from '../lib/url';
 
 const recentPosts = (await getCollection('posts'))
   .filter(p => !p.data.draft)
@@ -25,17 +26,17 @@ const recentPosts = (await getCollection('posts'))
         <div class="card">
           <h3>&ldquo;I need to figure out what to do with AI&rdquo;</h3>
           <p class="text-muted">AI strategy and roadmapping, discovery workshops, feasibility assessments. Honest guidance on what&rsquo;s realistic.</p>
-          <a href="/services">Learn more &rarr;</a>
+          <a href={url('/services')}>Learn more &rarr;</a>
         </div>
         <div class="card">
           <h3>&ldquo;I need someone senior to lead the AI work&rdquo;</h3>
           <p class="text-muted">Fractional AI Lead / CTO, embedded technical leadership, team building. Senior expertise without the full-time hire.</p>
-          <a href="/services">Learn more &rarr;</a>
+          <a href={url('/services')}>Learn more &rarr;</a>
         </div>
         <div class="card">
           <h3>&ldquo;I need an honest outside perspective&rdquo;</h3>
           <p class="text-muted">Technical due diligence, architecture review, vendor assessment, AI ethics and governance advisory.</p>
-          <a href="/services">Learn more &rarr;</a>
+          <a href={url('/services')}>Learn more &rarr;</a>
         </div>
       </div>
     </div>
@@ -47,7 +48,7 @@ const recentPosts = (await getCollection('posts'))
       <h2>Recent writing</h2>
       <div class="grid-3 mt-3">
         {recentPosts.map(post => (
-          <a href={`/writing/${post.id}`} class="card-link">
+          <a href={url(`/writing/${post.id}`)} class="card-link">
             <article class="card">
               <p class="text-muted" style="font-size:0.85rem;">
                 {new Date(post.data.date).toLocaleDateString('en-GB', { year: 'numeric', month: 'long' })}

--- a/src/pages/writing.astro
+++ b/src/pages/writing.astro
@@ -1,6 +1,7 @@
 ---
 import Base from '../layouts/Base.astro';
 import { getCollection } from 'astro:content';
+import { url } from '../lib/url';
 
 const posts = (await getCollection('posts'))
   .filter(p => !p.data.draft)
@@ -15,7 +16,7 @@ const posts = (await getCollection('posts'))
       <p class="mt-2">
         <a href="https://reproducible.substack.com" target="_blank" rel="noopener">Subscribe on Substack &rarr;</a>
         &nbsp;&middot;&nbsp;
-        <a href="/rss.xml">RSS feed &rarr;</a>
+        <a href={url('/rss.xml')}>RSS feed &rarr;</a>
       </p>
     </div>
   </section>
@@ -24,7 +25,7 @@ const posts = (await getCollection('posts'))
     <div class="container">
       <div class="grid-2">
         {posts.map(post => (
-          <a href={`/writing/${post.id}`} class="card-link">
+          <a href={url(`/writing/${post.id}`)} class="card-link">
             <article class="card">
               <p class="text-muted" style="font-size:0.85rem;">
                 {new Date(post.data.date).toLocaleDateString('en-GB', { year: 'numeric', month: 'long', day: 'numeric' })}

--- a/src/pages/writing/[id].astro
+++ b/src/pages/writing/[id].astro
@@ -1,6 +1,7 @@
 ---
 import Base from '../../layouts/Base.astro';
 import { getCollection, render } from 'astro:content';
+import { url } from '../../lib/url';
 
 export async function getStaticPaths() {
   const posts = await getCollection('posts');
@@ -48,7 +49,7 @@ const twitterUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(s
       {post.data.originalUrl && (
         <p class="text-muted mt-2">Originally published at <a href={post.data.originalUrl} target="_blank" rel="noopener">{new URL(post.data.originalUrl).hostname}</a></p>
       )}
-      <a href="/writing" class="btn btn--outline mt-3">&larr; All writing</a>
+      <a href={url('/writing')} class="btn btn--outline mt-3">&larr; All writing</a>
     </footer>
   </article>
 </Base>


### PR DESCRIPTION
PR previews are served from a subpath (/pr-preview/pr-<number>/), but the
site linked internally with hardcoded root-absolute paths, which would
escape the preview and land back on the live site.

Internal links and asset references now go through a url() helper that
prefixes Astro's configured base. With the default base of "/" the helper
is a no-op, so production output is byte-identical.

Builds served from a subpath additionally emit a noindex robots meta tag
and canonicalise to the production URL, so previews stay out of search
results.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MHNbaSspkaLoQdMkoNUzxT