### PR TITLE
Add post: Preview Every Change Before It Ships

### DIFF
--- a/src/content/posts/preview-every-change-before-it-ships.md
+++ b/src/content/posts/preview-every-change-before-it-ships.md
@@ -1,0 +1,42 @@
+---
+title: "Preview Every Change Before It Ships"
+date: "2026-08-06"
+excerpt: "A pull request diff tells you what changed in the template. It tells you nothing about what the reader will see. Here's how I wired per-PR previews into this site, and the one trap that nearly made them useless."
+tags: ["software-engineering", "ci-cd", "reproducibility"]
+---
+
+Static sites are easy to deploy and surprisingly hard to review. A pull request on this site shows me that a template changed, that a helper gained an argument, that some CSS moved. What it does not show me is the thing that actually matters: what the page looks like to somebody reading it.
+
+So I did what I should have done at the start, and wired up per-pull-request previews. Every PR now builds the whole site and publishes it to its own URL. I click the link in the PR, I look at the page, and then I merge. No local checkout, no "looks fine to me" based on a diff of Astro templates.
+
+## Sharing one branch with production
+
+GitHub Pages allows exactly one deployment source per repository, which is the constraint the whole design falls out of. If previews are going to live on Pages alongside the live site, they have to share it: production at the root, each preview in a subdirectory keyed by PR number.
+
+That is a mildly annoying arrangement, and it has one genuinely sharp edge. The production deploy has to be told not to delete the previews when it publishes, or every merge to `main` quietly wipes the preview of every other open PR. One line of configuration, and an afternoon of confusion if you miss it.
+
+## The trap: links that escape
+
+Here is the part I would not have predicted. Previews are served from a subpath — `/pr-preview/pr-42/` rather than `/` — and this site, like most, was written with root-absolute internal links:
+
+```html
+<a href="/services">Learn more</a>
+```
+
+That link works perfectly in production. In a preview it points at `/services` on the live domain. The preview loads, looks entirely correct, and then throws you out onto the real site the moment you click anything.
+
+The tempting fix is the build tool's base path setting, and it does not save you. It rewrites what the framework generates — bundled assets, generated routes — but a hardcoded string in a template is just a string. It stays exactly as you typed it.
+
+The actual fix is unglamorous: route every internal link through a helper that prefixes the configured base, and stop writing raw paths.
+
+```astro
+<a href={url('/services')}>Learn more</a>
+```
+
+Now a preview is genuinely self-contained. Navigate around inside it and you stay inside it.
+
+Two smaller things worth doing while you are in there: have preview builds emit `noindex`, and point their canonical URLs at production. Otherwise you have quietly published a dozen near-duplicate copies of your site and invited search engines to rank them against each other.
+
+## Worth it
+
+None of this is clever. It is about an hour of work and a helper function of six lines. But it changes the review question from *does this diff look right* to *does this page look right*, and those turn out to be very different questions.

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -13,6 +13,10 @@ const recentPosts = (await getCollection('posts'))
   <!-- Hero -->
   <section class="hero">
     <div class="container hero-inner">
+      <p class="smoke-test">
+        Preview smoke test &mdash; close this PR without merging.
+        Serving from base <code>{import.meta.env.BASE_URL}</code>
+      </p>
       <h1>Senior AI leadership for organisations that need expertise, not hype.</h1>
       <p class="hero-sub">I help public sector teams, not-for-profits, and growing companies figure out what to do with AI, and then do it.</p>
       <a href="https://cal.eu/mattupson" target="_blank" rel="noopener" class="btn btn--primary">Book a call</a>
@@ -73,6 +77,15 @@ const recentPosts = (await getCollection('posts'))
 <style>
   .hero {
     padding: 6rem 0 5rem;
+  }
+
+  .smoke-test {
+    margin-bottom: 1.5rem;
+    padding: 0.75rem 1rem;
+    border: 1px dashed var(--color-accent);
+    border-radius: 4px;
+    font-size: 0.9rem;
+    color: var(--color-text-muted);
   }
 
   .hero-inner {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -13,10 +13,6 @@ const recentPosts = (await getCollection('posts'))
   <!-- Hero -->
   <section class="hero">
     <div class="container hero-inner">
-      <p class="smoke-test">
-        Preview smoke test &mdash; close this PR without merging.
-        Serving from base <code>{import.meta.env.BASE_URL}</code>
-      </p>
       <h1>Senior AI leadership for organisations that need expertise, not hype.</h1>
       <p class="hero-sub">I help public sector teams, not-for-profits, and growing companies figure out what to do with AI, and then do it.</p>
       <a href="https://cal.eu/mattupson" target="_blank" rel="noopener" class="btn btn--primary">Book a call</a>
@@ -77,15 +73,6 @@ const recentPosts = (await getCollection('posts'))
 <style>
   .hero {
     padding: 6rem 0 5rem;
-  }
-
-  .smoke-test {
-    margin-bottom: 1.5rem;
-    padding: 0.75rem 1rem;
-    border: 1px dashed var(--color-accent);
-    border-radius: 4px;
-    font-size: 0.9rem;
-    color: var(--color-text-muted);
   }
 
   .hero-inner {


### PR DESCRIPTION
Adds a short post about wiring per-PR previews into this site — the trap where root-absolute links escape a subpath preview, and the `noindex`/canonical handling.

This replaces the temporary smoke-test banner, so the PR is now something worth merging rather than closing. It also serves as the real end-to-end check of the preview pipeline: a new post is exactly the kind of change you want to see rendered before it goes out.

## Draft — read it before merging

**The words are mine, not yours.** It's written to match the voice on the rest of the site (first person, British spelling, no hype) and every technical claim describes what we actually built here, so there's nothing invented. But it's your byline, so please read it properly and edit anything that doesn't sound like you.

If you'd rather not publish it, set `draft: true` in the frontmatter and it drops out of the homepage, the writing index, and the RSS feed while still rendering in the preview build.

## What to check in the preview

- The post renders at `/writing/preview-every-change-before-it-ships`
- It appears on the homepage under "Recent writing", and on `/writing`
- The code blocks and headings look right
- Navigating around stays **inside** `/pr-preview/pr-47/` — this is the base-awareness check from #46

Verified locally in both modes; the subpath build links to `/pr-preview/pr-47/writing/preview-every-change-before-it-ships`, and the post shows up in the homepage, writing index, and RSS in both.

## Note on the preview link

The preview will build and comment, but the URL won't resolve until `deploy.yml` is on `main` and Pages is switched to `gh-pages` — the root of that branch is still empty. Once that's done, re-trigger this PR and the link will work.