### PR TITLE
Add PR preview workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,3 +38,4 @@ jobs:
     steps:
       - id: deployment
         uses: actions/deploy-pages@v4
+

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,4 +38,3 @@ jobs:
     steps:
       - id: deployment
         uses: actions/deploy-pages@v4
-

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,45 @@
+name: PR preview
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, closed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: pr-preview-${{ github.event.number }}
+  cancel-in-progress: true
+
+jobs:
+  preview:
+    # Pull requests from forks get a read-only token, so they cannot deploy.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        if: github.event.action != 'closed'
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+        if: github.event.action != 'closed'
+
+      # The preview is served from a subpath, so the build needs a matching base
+      # for internal links and assets to resolve. See src/lib/url.ts.
+      - run: npm run build -- --base /pr-preview/pr-${{ github.event.number }}
+        if: github.event.action != 'closed'
+
+      # Deploys to gh-pages under pr-preview/pr-N/ and comments the URL on the
+      # PR. On close, removes the directory and the comment.
+      - uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: dist
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview
+          pages-base-url: https://mattupson.com/
+          action: auto


### PR DESCRIPTION
Adds per-PR GitHub Pages previews. Still a **draft** — one blocker left.

`pr-preview.yml` is correct and already proven to work: the run on this PR built and deployed successfully, and the deployed HTML has correctly base-prefixed links (`href="/pr-preview/pr-48/about"`). Those URLs just aren't reachable yet, because Pages isn't serving `gh-pages`.

## Blocker — `deploy.yml` still isn't replaced

`Fix deploy.yml` (c62ef6d) only removed the trailing newline, so the file is now byte-identical to the one on `main`. This branch currently makes no change to how `main` deploys.

The evidence is on `gh-pages`, which the preview run created:

```
gh-pages/
└── pr-preview/
    └── pr-48/     ← preview only; root is empty, no CNAME
```

Nothing writes the site to the **root** of that branch, because `main` still deploys through `actions/deploy-pages`. Switching Pages over to `gh-pages` in this state serves an empty root — mattupson.com would 404.

`deploy.yml` needs replacing in full:

```yaml
name: Deploy to GitHub Pages

on:
  push:
    branches: [main]
  workflow_dispatch:

permissions:
  contents: write

concurrency:
  group: deploy-main
  cancel-in-progress: false

jobs:
  deploy:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - uses: actions/setup-node@v4
        with:
          node-version: 22
          cache: npm
      - run: npm ci
      - run: npm run build
      - uses: JamesIves/github-pages-deploy-action@v4
        with:
          branch: gh-pages
          folder: dist
          # PR previews live on the same branch under pr-preview/; leave them alone.
          clean-exclude: pr-preview/
```

`permissions: contents: write` lets the job push to `gh-pages`; `clean-exclude` stops a production deploy from wiping every open PR's preview. Dropping either breaks it.

## Correction — the earlier "based on pre-#46 main" blocker was wrong

I previously said this branch would revert #46 and delete `src/lib/url.ts`. **That was incorrect, and no rebase or "Update branch" is needed.**

I'd read a two-dot `git diff main..branch`, which shows the branch merely *lacking* main's newer commits. Merging is a three-way operation against the merge base, and this branch only touches `.github/workflows/`. A test merge into `main` confirms it:

```
 .github/workflows/pr-preview.yml | 45 +++++++++++++++++++++++++++++++
 1 file changed, 45 insertions(+)
```

`src/lib/url.ts` survives. That also matches GitHub's own Files-changed tab, which uses the three-dot diff and shows only `pr-preview.yml`. Apologies for the detour.

## Remaining steps, in this order

1. Replace `deploy.yml` as above, then merge this PR.
2. Let the `main` deploy run to green — it populates the root of `gh-pages` and restores `CNAME` there, while `clean-exclude` preserves the existing `pr-preview/pr-48/`.
3. **Only then**: Settings → Pages → Source → *Deploy from a branch* → `gh-pages` → `/ (root)`.
4. Re-trigger #47 to see a preview at `https://mattupson.com/pr-preview/pr-47/`.