### PR TITLE
Publish main to gh-pages so previews and production can share Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,3 +38,4 @@ jobs:
     steps:
       - id: deployment
         uses: actions/deploy-pages@v4
+

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,4 +38,3 @@ jobs:
     steps:
       - id: deployment
         uses: actions/deploy-pages@v4
-

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,16 +6,14 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
 concurrency:
-  group: pages
+  group: deploy-main
   cancel-in-progress: false
 
 jobs:
-  build:
+  deploy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -25,16 +23,9 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build
-      - uses: actions/upload-pages-artifact@v3
+      - uses: JamesIves/github-pages-deploy-action@v4
         with:
-          path: dist/
-
-  deploy:
-    needs: build
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - id: deployment
-        uses: actions/deploy-pages@v4
+          branch: gh-pages
+          folder: dist
+          # PR previews live on the same branch under pr-preview/; leave them alone.
+          clean-exclude: pr-preview/

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,45 @@
+name: PR preview
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, closed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: pr-preview-${{ github.event.number }}
+  cancel-in-progress: true
+
+jobs:
+  preview:
+    # Pull requests from forks get a read-only token, so they cannot deploy.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        if: github.event.action != 'closed'
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+        if: github.event.action != 'closed'
+
+      # The preview is served from a subpath, so the build needs a matching base
+      # for internal links and assets to resolve. See src/lib/url.ts.
+      - run: npm run build -- --base /pr-preview/pr-${{ github.event.number }}
+        if: github.event.action != 'closed'
+
+      # Deploys to gh-pages under pr-preview/pr-N/ and comments the URL on the
+      # PR. On close, removes the directory and the comment.
+      - uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: dist
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview
+          pages-base-url: https://mattupson.com/
+          action: auto


### PR DESCRIPTION
The last piece of the preview setup. `pr-preview.yml` is already on `main` from #48 and working; this switches `main`'s own deploy so the two can coexist.

## Net change: one file

`pr-preview.yml` is byte-identical to the copy already on `main`, so despite the branch's history the merge resolves to a single file:

```
 .github/workflows/deploy.yml | 25 ++++++++-----------------
 1 file changed, 8 insertions(+), 17 deletions(-)
```

Test-merged into `main` locally: **0 conflicts**.

## Why this is needed

GitHub Pages allows exactly one deployment source. Previews live on `gh-pages`, so `main` has to publish there too — production at the root, previews under `pr-preview/pr-N/`.

Right now `main` still deploys through `actions/deploy-pages`, so nothing ever writes the site to the **root** of `gh-pages`. That branch currently holds only preview subdirectories, with no `index.html` and no `CNAME`. This PR is what populates it.

Two load-bearing lines:

- `permissions: contents: write` — lets the job push to `gh-pages`. The old `pages: write` / `id-token: write` pair was for the artifact API and is no longer used.
- `clean-exclude: pr-preview/` — stops each production deploy from wiping every open PR's preview.

## Order of operations after merging

1. Merge. The `Deploy to GitHub Pages` run fires and publishes the site to the root of `gh-pages`. Expect a larger commit than the preview ones — it's the whole site. Let it go green.
2. Confirm `gh-pages` has **`index.html` and `CNAME`** at its root. `CNAME` ships from `public/`, and it's what preserves the custom domain once Pages serves the branch.
3. **Only then**: Settings → Pages → Source → *Deploy from a branch* → `gh-pages` → `/ (root)`.

Doing 3 before 2 serves an empty root and takes mattupson.com down. Nothing before step 3 affects the live site — until the source is switched, Pages keeps serving the existing Actions deployment.

## Then

Re-trigger #47 (push a commit, or close and reopen) and its preview link should resolve at `https://mattupson.com/pr-preview/pr-47/`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MHNbaSspkaLoQdMkoNUzxT)_